### PR TITLE
changed script to only accept particles in mrc or mrcs fromat

### DIFF
--- a/ManifoldEM/util.py
+++ b/ManifoldEM/util.py
@@ -43,7 +43,7 @@ def is_valid_host(hostname):
 
 def get_image_width_from_stack(stack_file: str):
     img_width = 0
-    if stack_file.endswith('.mrcs'):
+    if stack_file.endswith('.mrcs') or stack_file.endswith('.mrc'):
         mrc = mrcfile.mmap(params.img_stack_file, mode='r')
         if not mrc.is_image_stack():
             mrc.close()
@@ -53,7 +53,7 @@ def get_image_width_from_stack(stack_file: str):
         img_width = mrc.data[0].shape[0]
         mrc.close()
     else:
-        img_width = int(np.sqrt(os.path.getsize(stack_file) / (4 * params.num_part)))
+        raise ValueError('Particles must be in mrc or mrcs format.')
 
     return img_width
 


### PR DESCRIPTION
Unless we have a good reason...this should only accept particles in mrc or mrcs format. The old method of guessing particle size based on file size is a bit weird and led to some weird bugs if the user has a sym link for the particle stack. 

This practice is probably not uncommon for cryoem stacks because cryosparc makes heavy use of symlinks.